### PR TITLE
Fix Nav elements on window resize

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -19,6 +19,7 @@ import {
 import ProfileSection from "./Profile";
 import UserService from "../services/UserService";
 import ToastNotify from "./utils/ToastNotify";
+import "../styles/carbon-override.scss"
 
 const BUTTON_FEEDBACK = "BUTTON_FEEDBACK";
 const MenuLink = (props) => {

--- a/src/styles/carbon-override.scss
+++ b/src/styles/carbon-override.scss
@@ -1,0 +1,4 @@
+// forces the navigation items to be displayed at all viewport sizes
+.cds--header__nav {
+    display: block;
+}


### PR DESCRIPTION
- Fixes: https://github.com/PDeXchange/pac/issues/431
- Fixes nav element disappearence by overriding the default carbon style.
- This is a known issue as mentioned here: https://github.com/carbon-design-system/carbon-angular-starter/issues/30

<img width="1726" height="598" alt="image" src="https://github.com/user-attachments/assets/eac1233d-d6eb-4aa3-8e65-6847b8d704ad" />
